### PR TITLE
Use actualRange for inputs

### DIFF
--- a/DDT/DDT/Views/MainView.swift
+++ b/DDT/DDT/Views/MainView.swift
@@ -25,14 +25,14 @@ extension MainView: View {
                       range: desiredRange(inCelsius: isCelsius))
         ComponentView(name: "Ambient",
                       temp: $ambient,
-                      range: desiredRange(inCelsius: isCelsius))
+                      range: actualRange(inCelsius: isCelsius))
         ComponentView(name: "Flour",
                       temp: $flour,
-                      range: desiredRange(inCelsius: isCelsius))
+                      range: actualRange(inCelsius: isCelsius))
         if hasPreferment {
           ComponentView(name: "Preferment",
                         temp: $preferment,
-                        range: desiredRange(inCelsius: isCelsius))
+                        range: actualRange(inCelsius: isCelsius))
         }
       }
       .navigationBarTitle("DDT Calculator º\(isCelsius ? "C" : "F")")


### PR DESCRIPTION
I think you were intending to use `actualRange` for the sliders representing the ambient temperature and the ingredient temperatures. Otherwise the range seems to be too narrow